### PR TITLE
Fix case issue with returntype attributes

### DIFF
--- a/src/basecompletions/json/cfml_tags.json
+++ b/src/basecompletions/json/cfml_tags.json
@@ -410,7 +410,7 @@
       "access": ["private", "package", "public", "remote"],
       "output": ["true", "false"],
       "returnformat": ["JSON", "plain", "WDDX"],
-      "returntype": ["Any", "Array", "Binary", "boolean", "date", "guid", "Numeric", "Query", "String", "Struct", "UUID", "variablename", "void", "xml", "(component name)"],
+      "returntype": ["any", "array", "binary", "boolean", "date", "guid", "numeric", "query", "string", "struct", "UUID", "variablename", "void", "xml", "(component name)"],
       "securejson": ["true", "false"],
       "verifyclient": ["true", "false"]
     }


### PR DESCRIPTION
The available attribute options for returntype in the <cffunction> tag had some of the arguments with capital first letters:

"returntype": ["Any", "Array", "binary", "boolean", "date", "guid", "numeric", "Query", "String", "Struct", "UUID", "variablename", "void", "xml", "(component name)"],

It was odd to me that some had a capital first letter and others did not. Nearly every other attribute option in the JSON file has all lowercase.