### PR TITLE
Added a semicolon to the writeOutput key binding

### DIFF
--- a/inputmaps/Default (Linux).sublime-keymap
+++ b/inputmaps/Default (Linux).sublime-keymap
@@ -46,11 +46,11 @@
       {"key": "selector", "operator": "not_equal", "operand": "source.cfml.script"}
     ]
   },
-  // ctrl+shift+o  writeOutput()
+  // ctrl+shift+o  writeOutput();
   {
     "keys": ["ctrl+shift+o"],
     "command": "insert_snippet",
-    "args": {"contents": "writeOutput(${1:$SELECTION})"},
+    "args": {"contents": "writeOutput(${1:$SELECTION});"},
     "context": [
       {"key": "selector", "operand": "source.cfml.script" }
     ]

--- a/inputmaps/Default (OSX).sublime-keymap
+++ b/inputmaps/Default (OSX).sublime-keymap
@@ -46,11 +46,11 @@
       {"key": "selector", "operator": "not_equal", "operand": "source.cfml.script"}
     ]
   },
-  // ctrl+shift+o  writeOutput()
+  // ctrl+shift+o  writeOutput();
   {
     "keys": ["super+shift+o"],
     "command": "insert_snippet",
-    "args": {"contents": "writeOutput(${1:$SELECTION})"},
+    "args": {"contents": "writeOutput(${1:$SELECTION});"},
     "context": [
       {"key": "selector", "operand": "source.cfml.script" }
     ]

--- a/inputmaps/Default (Windows).sublime-keymap
+++ b/inputmaps/Default (Windows).sublime-keymap
@@ -46,11 +46,11 @@
       {"key": "selector", "operator": "not_equal", "operand": "source.cfml.script"}
     ]
   },
-  // ctrl+shift+o  writeOutput()
+  // ctrl+shift+o  writeOutput();
   {
     "keys": ["ctrl+shift+o"],
     "command": "insert_snippet",
-    "args": {"contents": "writeOutput(${1:$SELECTION})"},
+    "args": {"contents": "writeOutput(${1:$SELECTION});"},
     "context": [
       {"key": "selector", "operand": "source.cfml.script" }
     ]


### PR DESCRIPTION
This is a minor inconvenience when using the key binding. This also
makes it consistent with the writeDump keybind.